### PR TITLE
feat: add endpoint for user verification status

### DIFF
--- a/src/main/kotlin/com/nullius_real_estate/api_gateway/SecurityConfig.kt
+++ b/src/main/kotlin/com/nullius_real_estate/api_gateway/SecurityConfig.kt
@@ -25,6 +25,7 @@ class SecurityConfig {
                     "/api/auth/register",
                     "/api/auth/login",
                     "/api/auth/user/{keycloakUserId}/is-verified",
+                    "/api/auth/user/{keycloakUserId}/resend-verification-email",
 
 //                    Docs
                     "/webjars/swagger-ui/**",


### PR DESCRIPTION
This pull request includes a small but important update to the `SecurityConfig` class in the `api_gateway` module. The change adds a new endpoint to the list of publicly accessible URLs.

* [`src/main/kotlin/com/nullius_real_estate/api_gateway/SecurityConfig.kt`](diffhunk://#diff-f4d8123f8fa54ee3aad5a97466d498f67d78e85205e52b45969bac5c4b07d9baR28): Added the `/api/auth/user/{keycloakUserId}/resend-verification-email` endpoint to the list of permitted URLs.